### PR TITLE
Add stack.yaml and capability for running tests with stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 
 # Generated docs
 docs/
+
+# Stack
+.stack-work/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,8 @@
+flags:
+  stencil:
+    newtransformers: true
+    buildexecutable: false
+packages:
+- '.'
+extra-deps: []
+resolver: lts-3.13

--- a/stencil.cabal
+++ b/stencil.cabal
@@ -116,4 +116,5 @@ test-suite doctest
                   , stencil
                   , Glob
                   , doctest
-
+                  , directory
+                  , filepath

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -1,12 +1,65 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Main (main) where
 
+import Control.Exception (handle, SomeException)
+import System.Environment (getEnv)
+import System.Directory (doesDirectoryExist
+                        , getDirectoryContents)
+import System.FilePath ((</>))
 import System.FilePath.Glob (glob)
 import Test.DocTest         (doctest)
 
+
 main :: IO ()
-main = glob "src/**/*.hs" >>= doctest . (defaultOpts ++)
+main = do
+  distDir <- findDistDir
+  let defaultOpts = getOptions distDir
+  glob "src/**/*.hs" >>= doctest . (defaultOpts ++)
    where
-     defaultOpts = [ "-XCPP"
-                   , "-optP-include"
-                   , "-optPdist/build/autogen/cabal_macros.h"
-                   ]
+     getOptions distDir = [ "-XCPP"
+                          , "-optP-include"
+                          , "-optP" ++ distDir ++ "/build/autogen/cabal_macros.h"
+                          ]
+
+findDistDir :: IO FilePath
+findDistDir = do
+  distDir <- isDistDir
+  case distDir of
+    Just fp -> return fp
+    Nothing -> do
+      stackDir <- isStackDir
+      case stackDir of
+        Nothing -> return "dist"
+        Just dir -> return dir
+
+isDistDir :: IO (Maybe FilePath)
+isDistDir = do
+  exists <- doesDirectoryExist "dist"
+  if exists then return (Just "dist") else return Nothing
+
+isStackDir :: IO (Maybe FilePath)
+isStackDir = handle (\(_ :: SomeException) -> getStackDir) $ do
+    stackDir <- getEnv "HASKELL_DIST_DIR"
+    return $ Just stackDir
+
+-- More fragile way of getting stack dir
+-- relies on there being only one item in dist/ARCH/cabal-vers/
+-- necessary for old versions of stack before HASKELL_DIST_DIR
+getStackDir :: IO (Maybe FilePath)
+getStackDir = do
+  let stackDir = ".stack-work/dist"
+  exists <- doesDirectoryExist stackDir
+  if not exists then return Nothing else do
+      stackWithArch <- getSoleItem stackDir
+      case stackWithArch of
+        Just fpath -> getSoleItem fpath
+        Nothing -> return Nothing
+
+getSoleItem :: FilePath -> IO (Maybe FilePath)
+getSoleItem fpath = do
+  contents <- getDirectoryContents fpath
+  let soleValue = filter (\fp -> head fp /= '.') contents
+  if null soleValue
+    then return Nothing
+    else return $ Just (fpath </> head soleValue)


### PR DESCRIPTION
### Description

Stack can be a nice alternative for building and testing Haskell projects. However, upon adding a `stack.yaml` and building this project with `stack`, I found that the following `DocTest` option made the doctests error out:

```
`-optPdist/build/autogen/cabal_macros.h`
```

The `cabal_macros.h` header file was not present where it was looking for it (because the project had not been built with `cabal` and no `dist` directory was present).

In order to fix this error, I could build the project with cabal and re-run the tests using `stack` or I could attempt to make the `DocTest` module a bit more flexible by seeking out the proper build directory itself. Since other users might use `stack` in a similar workflow in the future, I opted for the latter.
#### Note

Only recent versions of `stack` include a `HASKELL_DIST_DIR` environment variable, so I also included a fallback function that attempts to find the `stack` dist directory for older versions of `stack`.

_See also:_
1. Discussion on [haskell-stack group](https://groups.google.com/forum/#!topic/haskell-stack/OoP88_VckhY)
2. [Related issue in doctest library](https://github.com/sol/doctest/issues/89)
3. [Related issue in linear](https://github.com/ekmett/linear/issues/89)
### Changes Included in this PR
- Adds `stack.yaml` created by running `stack new`.
- Modifies `DocTest.hs` to look for a `stack-work` "dist dir" if the regular `dist` directory does not exist and inserts the proper `cabal_macros.h` option using that `stack-work` directory.
